### PR TITLE
* fluentd.conf.rt API_KEY placeholder changed to DATADOG_API_KEY so i…

### DIFF
--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -256,7 +256,7 @@
 <match jfrog.**>
   @type datadog
   @id datadog_agent_jfrog_artifactory
-  api_key API_KEY
+  api_key DATADOG_API_KEY
   #optional
   include_tag_key true
   dd_source fluentd


### PR DESCRIPTION
fluentd.conf.rt API_KEY placeholder changed to DATADOG_API_KEY so it's consistent with fluentd.conf.xray. It's needed in the installers so we can use the same code to replace the DATADOG_API_KEY placeholder in the same way for the artifactory and xray.