### PR TITLE
Remove -ha typo from no -ha artifactory install

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Artifactory ⎈:
 Replace the `datadog_api_key` at the end of the yaml file with apiKey from [Datadog](https://docs.datadoghq.com/account_management/api-app-keys/) and then run the following helm command:
 
 ```text
-helm upgrade --install artifactory-ha  jfrog/artifactory-ha \
+helm upgrade --install artifactory  jfrog/artifactory \
        --set artifactory.masterKey=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF \
        --set artifactory.joinKey=EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE \
        -f helm/artifactory-values.yaml


### PR DESCRIPTION
Artifactory helm install had -ha in a command which shouldn't be there. This is causing confusion for customers.