### PR TITLE
Include the `artifactory-request-out` log

### DIFF
--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -117,6 +117,19 @@
 </filter>
 <source>
   @type tail
+  @id artifactory_request_out_tail
+  path "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/log/artifactory-request-out.log"
+  pos_file "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/log/artifactory-request-out.log.pos"
+  tag jfrog.rt.request.out
+  <parse>
+    @type regexp
+    expression ^(?<timestamp>[^ ]*)\|(?<trace_id>[^\|]*)\|(?<remote_repo_name>[^\|]*)\|(?<username>[^\|]*)\|(?<request_method>[^\|]*)\|(?<remote_url>[^\|]*)\|(?<return_status>[^\|]*)\|(?<response_content_length>[^\|]*)\|(?<request_content_length>[^\|]*)\|(?<request_duration>[^\|]*)$
+    time_key timestamp
+    time_format %Y-%m-%dT%H:%M:%S.%LZ
+  </parse>
+</source>
+<source>
+  @type tail
   @id frontend_request_tail
   path "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/log/frontend-request.log"
   pos_file "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/log/frontend-request.log.pos"


### PR DESCRIPTION
Including the `artifactory-request-out` log for monitoring calls to remotes in Datadog