### PR TITLE
Callhome implementation with documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # JFrog Log Analytics Changelog
 All changes to the log analytics integration will be documented in this file.
 
+## [0.8.0] - Feb 09, 2022
+* Added call home functionality to artifactory fluent configuration.
+
 ## [0.7.0] - Oct 20, 2020
 * Fixing issue with ip_address in access logs having space and . at the end
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ For non-k8s based installations below is a reference to the Docker image locatio
 ````text
 Artifactory: 
 export JF_PRODUCT_DATA_INTERNAL=/var/opt/jfrog/artifactory/
+To authenticate with the API:
+export JF_USER=<Your Artifactory Username>
+export JF_PASS=<Your Artifactory Password>
 ````
 
 ````text

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -186,22 +186,31 @@
     log_source ${tag}
   </record>
 </filter>
+# <source>
+#   @type exec
+#   tag jfrog.callhome
+#   command "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/fluentd-1.11.0-linux-x86_64/lib/ruby/bin/gem list --local | grep fluent | sed 's/ (/:/g' | sed 's/)//g'  | sed ':a;N;$!ba;s/\n/\t/g'"
+#   run_interval 1d
+#   <parse>
+#     @type ltsv
+#   </parse>
+# </source>
+# <source>
+#   @type exec
+#   tag jfrog.callhome
+#   command /opt/td-agent/embedded/bin/gem list --local | grep fluent | sed 's/ (/:/g' | sed 's/)//g'  | sed ':a;N;$!ba;s/\n/\t/g'
+#   run_interval 1d
+#   <parse>
+#     @type ltsv
+#   </parse>
+# </source>
 <source>
   @type exec
   tag jfrog.callhome
-  command "#{ENV['JF_PRODUCT_DATA_INTERNAL']}/fluentd-1.11.0-linux-x86_64/lib/ruby/bin/gem list --local | grep fluent | sed 's/ (/:/g' | sed 's/)//g'  | sed ':a;N;$!ba;s/\n/\t/g'"
+  command "pwd"
   run_interval 1d
   <parse>
-    @type ltsv
-  </parse>
-</source>
-<source>
-  @type exec
-  tag jfrog.callhome
-  command /opt/td-agent/embedded/bin/gem list --local | grep fluent | sed 's/ (/:/g' | sed 's/)//g'  | sed ':a;N;$!ba;s/\n/\t/g'
-  run_interval 1d
-  <parse>
-    @type ltsv
+    @type none
   </parse>
 </source>
 <filter jfrog.callhome>
@@ -210,7 +219,7 @@
   keep_keys 'productId,features'
   enable_ruby true
   <record>
-    productId 'jfrogLogAnalytics/v0.1.0'
+    productId 'jfrogLogAnalyticsDatadog/0.8.0'
     features ${return(record.map { |k,v| { "featureId" => (k + ':' + v).to_sym} })}
   </record>
 </filter>
@@ -219,6 +228,11 @@
   endpoint http://localhost:8081/artifactory/api/system/usage
   open_timeout 5
   content_type application/json
+  <auth>
+    method basic
+    username "#{ENV['JF_USER']}"
+    password "#{ENV['JF_PASS']}"
+  </auth>
   <format>
     @type json
   </format>

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -210,7 +210,7 @@
   keep_keys 'productId,features'
   enable_ruby true
   <record>
-    productId 'jfrogLogAnalytics/v0.1.0'
+    productId 'jfrogLogAnalyticsDatadog/0.8.0'
     features ${return(record.map { |k,v| { "featureId" => (k + ':' + v).to_sym} })}
   </record>
 </filter>
@@ -219,6 +219,11 @@
   endpoint http://localhost:8081/artifactory/api/system/usage
   open_timeout 5
   content_type application/json
+  <auth>
+    method basic
+    username "#{ENV['JF_USER']}"
+    password "#{ENV['JF_PASS']}"
+  </auth>
   <format>
     @type json
   </format>


### PR DESCRIPTION
Call home implementation for datadog. This sends data back to artifactory via the artifactory API. 
This took a lot of testing haha, it looks small but testing it was the big time sink. 