### PR TITLE
use url instead of  endpoint

### DIFF
--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -207,7 +207,7 @@
 </filter>
 <match jfrog.callhome>
   @type http
-  endpoint http://localhost:8081/artifactory/api/system/usage
+  url http://localhost:8081/artifactory/api/system/usage
   open_timeout 5
   content_type application/json
   headers {"Authorization":"Bearer <TOKEN>"}

--- a/fluent.conf.rt6
+++ b/fluent.conf.rt6
@@ -98,7 +98,7 @@
 </filter>
 <match jfrog.callhome>
   @type http
-  endpoint http://localhost:8081/artifactory/api/system/usage
+  url http://localhost:8081/artifactory/api/system/usage
   open_timeout 5
   content_type application/json
   <format>

--- a/fluentd-ha/fluent.conf.aggregator
+++ b/fluentd-ha/fluent.conf.aggregator
@@ -305,7 +305,7 @@
 </filter>
 <match jfrog.callhome>
   @type http
-  endpoint http://localhost:8081/artifactory/api/system/usage
+  url http://localhost:8081/artifactory/api/system/usage
   open_timeout 5
   content_type application/json
   <format>


### PR DESCRIPTION
The current config file is returning the following error 
```[error]: config error file="/etc/td-agent/td-agent.conf" error_class=Fluent::ConfigError error="'url' parameter is required"```