### PR TITLE
Fix Xray request logs expression

### DIFF
--- a/fluent.conf.xray
+++ b/fluent.conf.xray
@@ -230,7 +230,7 @@
   tag jfrog.xray.xray.request
   <parse>
     @type regexp
-    expression ^(?<log_timestamp>[^ ]*)\|(?<trace_id>[^ ]*)\|(?<remote_address>[^|]++)\|(?<username>[^\|]*)\|(?<request_method>[^\|]*)\|(?<request_url>[^\|]*)\|(?<return_status>[^\|]*)\|(?<response_content_length>[^\|]*)\|(?<request_duration>.*)$
+    expression ^(?<log_timestamp>[^ ]*)\|(?<trace_id>[^ ]*)\|(?<remote_address>[^|]++)\|(?<username>[^\|]*)\|(?<request_method>[^\|]*)\|(?<request_url>[^\|]*)\|(?<return_status>[^\|]*)\|(?<request_content_length>[^\|]*)\|(?<response_content_length>[^\|]*)\|(?<request_duration>[^\|]*)\|(?<request_user_agent>.+)$
   </parse>
 </source>
 


### PR DESCRIPTION
The expression for Xray request logs is updated to parse all fields in the logs correctly.

Fields that were not parsed correctly are:
- request_content_length
- response_content_length
- request_duration
- request_user_agent

Reference: https://jfrog.com/help/r/jfrog-platform-administration-documentation/request-log