### PR TITLE
PTRENG-6234 - Fluentd sidecar version bumped to 4.5 to resolve fluent…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.5] - July 16, 2024
+* Fluentd sidecar version bumped to 4.5, to upgrade base image to bitnami/fluentd 1.17.0
+* Fixing fluent-plugin-jfrog-metrics issue (upgrading to 0.2.7) - resolving PTRENG-6234
+* Metrics documentation changes - resolving PTRENG-6186
+
 ## [1.0.4] - June 6, 2024
 * [BREAKING] Adding deprecation notice for partnership-pts-observability.jfrog.io docker registry
 * FluentD sidecar version bumped to 4.3, to upgrade base image to bitnami/fluentd 1.16.5

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The following document describes how to configure Datadog to gather logs, metric
 
 ## Versions Supported
 
-This integration is last tested with Artifactory 7.84.11 and Xray 3.92.7 versions.
+This integration is last tested with Artifactory 7.84.17 and Xray 3.92.7 versions.
 
 ## Table of Contents
 
@@ -31,13 +31,17 @@ If you don't have a DataDog apiKey:
 
 ## JFrog Metrics Setup
 
-Metrics collection is diabled by default in Artifactory by default. To enable metrics in Artifactory, make the following configuration changes to the [Artifactory System YAML](https://www.jfrog.com/confluence/display/JFROG/Artifactory+System+YAML).
+Metrics collection is disabled by default in Artifactory by default. For non-kubernetes installations, to enable metrics in Artifactory, make the following configuration changes to the [Artifactory System YAML](https://www.jfrog.com/confluence/display/JFROG/Artifactory+System+YAML):
+
+```yaml
+shared:
+    metrics:
+        enabled: true
 
 artifactory:
-metrics:
-enabled: true
-openMetrics:
-enabled: true
+    metrics:
+        enabled: true
+```
 Once this configuration is done and the application is restarted, metrics will be available in Open Metrics Format
 
 :bulb: Metrics are enabled by default in Xray.
@@ -67,7 +71,7 @@ For a Gem-based install, the Ruby Interpreter must be setup first. You can insta
 
    * Use the `SUDO` command  for multi-user installation. For more information, see the [RVM troubleshooting documentation](https://rvm.io/support/troubleshooting#sudo).
 2. After the RVM installation is complete, execute the command 'rvm -v' to verify.
-3. Install Ruby v2.7.0 or above with the command `rvm install <ver_num>`, (for example, `rvm install 2.7.5`).
+3. Install Ruby v3.3.0 or above with the command `rvm install <ver_num>`, (for example, `rvm install 3.3.0`).
 4. Verify the Ruby installation, execute `ruby -v`, gem installation `gem -v` and `bundler -v` to ensure all the components are intact.
 5. Install the FluentD gem with the command `gem install fluentd`.
 6. After FluentD is successfully installed, install the following plugins.
@@ -180,12 +184,11 @@ export MASTER_KEY=$(openssl rand -hex 32)
           --set artifactory.joinKey=$JOIN_KEY \
           --set artifactory.license.secret=artifactory-license \
           --set artifactory.license.dataKey=artifactory.cluster.license \
-          --set artifactory.metrics.enabled=true \
           --set artifactory.openMetrics.enabled=true \
           -n $INST_NAMESPACE --create-namespace
    ```
 
-   :bulb: Metrics collection is disabled by default in Artifactory. Please make sure that you are following the above `helm upgrade` command to enable them in Artifactory by setting to true both `artifactory.metrics.enabled` and `artifactory.openMetrics.enabled`
+   :bulb: Metrics collection is disabled by default in Artifactory. Please make sure that you are following the above `helm upgrade` command to enable them in Artifactory by setting `artifactory.openMetrics.enabled=true` as shown above
 
    Get the ip address of the newly deployed Artifactory:
 
@@ -228,9 +231,8 @@ export MASTER_KEY=$(openssl rand -hex 32)
 
    ```bash
    helm upgrade --install artifactory jfrog/artifactory \
-            --set artifactory.masterKey=$MASTER_KEY \
             --set artifactory.joinKey=$JOIN_KEY \
-            --set artifactory.metrics.enabled=true --set artifactory.openMetrics.enabled=true \
+            --set artifactory.openMetrics.enabled=true \
             --set databaseUpgradeReady=true --set postgresql.postgresqlPassword=$POSTGRES_PASSWORD --set nginx.service.ssloffload=true \
             --set datadog.api_key=$DATADOG_API_KEY \
             --set datadog.api_host=$DATADOG_API_HOST \
@@ -256,12 +258,11 @@ export MASTER_KEY=$(openssl rand -hex 32)
       --set artifactory.joinKey=$JOIN_KEY \
       --set artifactory.license.secret=artifactory-license \
       --set artifactory.license.dataKey=artifactory.cluster.license \
-      --set artifactory.metrics.enabled=true \
       --set artifactory.openMetrics.enabled=true \
       -n $INST_NAMESPACE
    ```
 
-   :bulb: Metrics collection is disabled by default in Artifactory-HA. Please make sure that you are following the above `helm upgrade` command to enable them in Artifactory-HA by setting to true both `artifactory.metrics.enabled` and `artifactory.openMetrics.enabled`
+   :bulb: Metrics collection is disabled by default in Artifactory-HA. Please make sure that you are following the above `helm upgrade` command to enable them in Artifactory by setting `artifactory.openMetrics.enabled=true` as shown above
 
    Get the ip address of the newly deployed Artifactory:
 
@@ -301,9 +302,8 @@ export MASTER_KEY=$(openssl rand -hex 32)
 
    ```bash
    helm upgrade --install artifactory-ha  jfrog/artifactory-ha \
-       --set artifactory.masterKey=$MASTER_KEY \
        --set artifactory.joinKey=$JOIN_KEY \
-       --set artifactory.metrics.enabled=true --set artifactory.openMetrics.enabled=true \
+       --set artifactory.openMetrics.enabled=true \
        --set databaseUpgradeReady=true --set postgresql.postgresqlPassword=$POSTGRES_PASSWORD --set nginx.service.ssloffload=true \
        --set datadog.api_key=$DATADOG_API_KEY \
        --set datadog.api_host=$DATADOG_API_HOST \
@@ -349,7 +349,7 @@ export XRAY_MASTER_KEY=$(openssl rand -hex 32)
 Use the same `joinKey` as you used in Artifactory installation to allow Xray node to successfully connect to Artifactory.
 
 ```bash
-helm upgrade --install xray jfrog/xray --set xray.jfrogUrl=http://my-artifactory-nginx-url \
+helm upgrade --install xray jfrog/xray --set xray.jfrogUrl=$JPD_URL \
        --set xray.masterKey=$XRAY_MASTER_KEY \
        --set xray.joinKey=$JOIN_KEY \
        --set datadog.api_key=$DATADOG_API_KEY \

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.15.2
+FROM bitnami/fluentd:1.17.0
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also

--- a/fluentd-installer/Dockerfile.fluentd.sidecar
+++ b/fluentd-installer/Dockerfile.fluentd.sidecar
@@ -1,5 +1,5 @@
 # Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.15.2
+FROM bitnami/fluentd:1.17.0
 LABEL maintainer "Partner Engineering <partner_support@jfrog.com>"
 
 USER root

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -15,7 +15,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -39,7 +39,7 @@ artifactory:
         - name: DATADOG_API_HOST
           value: {{ .Values.datadog.api_host }}
         - name: FLUENTD_CONF
-          value: ../../../../{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          value: ../../../..{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
 datadog:
   api_key: DATADOG_API_KEY
   api_host: DATADOG_API_HOST

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -15,7 +15,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
       imagePullPolicy: "IfNotPresent"
       volumeMounts: 
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
@@ -39,7 +39,7 @@ artifactory:
         - name: DATADOG_API_HOST
           value: {{ .Values.datadog.api_host }}
         - name: FLUENTD_CONF
-          value: ../../../../{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          value: ../../../..{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
 datadog:
   api_key: DATADOG_API_KEY
   api_host: DATADOG_API_HOST

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.3"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.5"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"
@@ -28,7 +28,7 @@ common:
         - name: JF_PRODUCT_DATA_INTERNAL
           value: {{ .Values.xray.persistence.mountPath }}
         - name: FLUENTD_CONF
-          value: ../../../../{{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          value: ../../../..{{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
         - name: JPD_URL
           value: {{ .Values.jfrog.observability.jpd_url }}
         - name: JPD_ADMIN_USERNAME


### PR DESCRIPTION
* Fluentd sidecar version bumped to 4.5, to upgrade base image to bitnami/fluentd 1.17.0
* Fixing fluent-plugin-jfrog-metrics issue (upgrading to 0.2.7) - resolving PTRENG-6234