### PR TITLE
PTRENG-6381 - Upgrade FluentD sidecar to 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.8] - September 12, 2024
+
+* FluentD sidecar image version bumped to 4.8, to add verify_ssl flag support for JFrog's FluentD metrics plugins
+
 ## [1.0.7] - August 19, 2024
 
 * FluentD sidecar image version bumped to 4.7, to add http proxy support for JFrog's FluentD metrics plugin

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.7"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.8"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.7"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.8"
       imagePullPolicy: "IfNotPresent"
       volumeMounts: 
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.7"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.8"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
Upgrade FluentD sidecar to 4.8 to add verify_ssl flag support for JFrog's FluentD metrics plugins (PTRENG-6381)

