### PR TITLE
PTRENG-6513 - Upgrade FluentD sidecar to version 4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.10] - November 7, 2024
+
+* FluentD sidecar image version bumped to 4.13, to reflect changes in `jfrog_siem` and `jfrog_send_metrics` FluentD plugins 
+
 ## [1.0.9] - October 25, 2024
 
 * Add support for metrics outbound payload compression, with `gzip_compression` FluentD param in `jfrog_send_metrics` plugin

--- a/README.md
+++ b/README.md
@@ -187,8 +187,6 @@ export MASTER_KEY=$(openssl rand -hex 32)
    helm upgrade --install artifactory jfrog/artifactory \
           --set artifactory.masterKey=$MASTER_KEY \
           --set artifactory.joinKey=$JOIN_KEY \
-          --set artifactory.license.secret=artifactory-license \
-          --set artifactory.license.dataKey=artifactory.cluster.license \
           --set artifactory.metrics.enabled=true \
           -n $INST_NAMESPACE --create-namespace
    ```
@@ -310,7 +308,7 @@ export MASTER_KEY=$(openssl rand -hex 32)
    ```bash
    helm upgrade --install artifactory-ha  jfrog/artifactory-ha \
        --set artifactory.joinKey=$JOIN_KEY \
-       --set artifactory.openMetrics.enabled=true \
+       --set artifactory.metrics.enabled=true \
        --set databaseUpgradeReady=true --set postgresql.postgresqlPassword=$POSTGRES_PASSWORD --set nginx.service.ssloffload=true \
        --set datadog.api_key=$DATADOG_API_KEY \
        --set datadog.api_host=$DATADOG_API_HOST \

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.9"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.13"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.9"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.13"
       imagePullPolicy: "IfNotPresent"
       volumeMounts: 
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.9"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.13"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
* Upgrade FluentD sidecar to version 4.13 to include changes made in `jfrog_siem` and `jfrog_metrics` FluentD plugins