### PR TITLE
Support for custom tag(like staging/production) in logs and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ We rely on environment variables to stream log files to your observability dashb
 * **JPD_ADMIN_USERNAME**: Artifactory username for authentication
 * **JFROG_ADMIN_TOKEN**: Artifactory [Access Token](https://jfrog.com/help/r/how-to-generate-an-access-token-video/artifactory-creating-access-tokens-in-artifactory) for authentication
 * **COMMON_JPD**: This flag should be set as true only for non-Kubernetes installations or installations where the JPD base URL is the same to access both Artifactory and Xray (for example, `https://sample_base_url/artifactory` or `https://sample_base_url/xray`)
+* **LOG_ENV**: Optional environment tag for categorizing logs and metrics (e.g., `staging`, `production`, `dev`). This tag will be added to all logs and metrics sent to Datadog as `env:<value>`
 
 Apply the `.env` files and run the fluentd wrapper with the following command, and note that the argument points to the `fluent.conf.*` file previously configured:
 
@@ -129,6 +130,7 @@ In order to run FluentD as a docker image to send the logs, violations, and metr
    * **JPD_ADMIN_USERNAME**: Artifactory username for authentication
    * **JFROG_ADMIN_TOKEN**: Artifactory [Access Token](https://jfrog.com/help/r/how-to-generate-an-access-token-video/artifactory-creating-access-tokens-in-artifactory) for authentication
    * **COMMON_JPD**: This flag should be set as true only for non-kubernetes installations or installations where JPD base URL is same to access both Artifactory and Xray (ex: https://sample_base_url/artifactory or https://sample_base_url/xray)
+   * **LOG_ENV**: Optional environment tag for categorizing logs and metrics (e.g., `staging`, `production`, `dev`). This tag will be added to all logs and metrics sent to Datadog as `env:<value>`
 6. Execute 'docker run -it --name jfrog-fluentd-datadog-rt -v <path_to_folder_contains_log_dir>:/var/opt/jfrog/artifactory --env-file docker.env <image_name>'
 
    The `<path_to_logs>` should be an absolute path where the Jfrog Artifactory Logs folder resides, such as a Docker based Artifactory Installation like`/var/opt/jfrog/artifactory/var/logs` on the docker host. For example:
@@ -234,7 +236,7 @@ export MASTER_KEY=$(openssl rand -hex 32)
    ```bash
    helm upgrade --install artifactory jfrog/artifactory \
             --set artifactory.joinKey=$JOIN_KEY \
-            --set databaseUpgradeReady=true --set postgresql.postgresqlPassword=$POSTGRES_PASSWORD --set nginx.service.ssloffload=true \
+            --set databaseUpgradeReady=true --set postgresql.auth.password=$POSTGRES_PASSWORD --set nginx.service.ssloffload=true \
             --set datadog.api_key=$DATADOG_API_KEY \
             --set datadog.api_host=$DATADOG_API_HOST \
             --set datadog.compress_data=$DATADOG_COMPRESS_DATA \
@@ -242,6 +244,7 @@ export MASTER_KEY=$(openssl rand -hex 32)
             --set jfrog.observability.jpd_url=$JPD_URL \
             --set jfrog.observability.username=$JPD_ADMIN_USERNAME \
             --set jfrog.observability.common_jpd=$COMMON_JPD \
+            --set jfrog.observability.log_env=$LOG_ENV \
             -f helm/artifactory-values.yaml \
             -n $INST_NAMESPACE
    ```
@@ -317,6 +320,7 @@ export MASTER_KEY=$(openssl rand -hex 32)
        --set jfrog.observability.jpd_url=$JPD_URL \
        --set jfrog.observability.username=$JPD_ADMIN_USERNAME \
        --set jfrog.observability.common_jpd=$COMMON_JPD \
+       --set jfrog.observability.log_env=$LOG_ENV \
        -f helm/artifactory-ha-values.yaml \
        -n $INST_NAMESPACE
    ```
@@ -368,6 +372,7 @@ helm upgrade --install xray jfrog/xray --set xray.jfrogUrl=$JPD_URL \
        --set jfrog.observability.jpd_url=$JPD_URL \
        --set jfrog.observability.username=$JPD_ADMIN_USERNAME \
        --set jfrog.observability.common_jpd=$COMMON_JPD \
+       --set jfrog.observability.log_env=$LOG_ENV \
        -f helm/xray-values.yaml \
        -n $INST_NAMESPACE
 ```

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -21,6 +21,7 @@
   url "https://api.#{ENV['DATADOG_API_HOST']}/api/v2/series"
   gzip_compression "#{ENV['DATADOG_COMPRESS_DATA']}"
   request_timeout 30s
+  ddtags ["env:#{ENV['LOG_ENV']}"]
   # @log_level debug
   # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
   # ddtags ["instance:test-artifactory", "cluster:GKE"]
@@ -379,6 +380,7 @@
     dd_source jfrog_platform
     service jfrog_artifactory
     host "http-intake.logs.#{ENV['DATADOG_API_HOST']}"
+    dd_tags "env:#{ENV['LOG_ENV']}"
     <buffer>
       flush_interval 1s
       # frequency of the buffer flush

--- a/fluent.conf.xray
+++ b/fluent.conf.xray
@@ -19,6 +19,7 @@
   apikey "#{ENV['DATADOG_API_KEY']}"
   url "https://api.#{ENV['DATADOG_API_HOST']}/api/v2/series"
   gzip_compression "#{ENV['DATADOG_COMPRESS_DATA']}"
+  ddtags ["env:#{ENV['LOG_ENV']}"]
   # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
   # ddtags ["instance:test-artifactory", "cluster:GKE"]
 </match>
@@ -142,6 +143,7 @@
   dd_source jfrog_platform
   service jfrog_xray
   host "http-intake.logs.#{ENV['DATADOG_API_HOST']}"
+  dd_tags "env:#{ENV['LOG_ENV']}"
   <buffer>
     flush_interval 1s
     # frequency of the buffer flush
@@ -328,6 +330,7 @@
     dd_source jfrog_platform
     service jfrog_xray
     host "http-intake.logs.#{ENV['DATADOG_API_HOST']}"
+    dd_tags "env:#{ENV['LOG_ENV']}"
     <buffer>
       flush_interval 1s
       # frequency of the buffer flush

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -45,6 +45,8 @@ artifactory:
           value: {{ .Values.datadog.verify_ssl | quote}}
         - name: DATADOG_COMPRESS_DATA
           value: {{ .Values.datadog.compress_data | quote }}
+        - name: LOG_ENV
+          value: {{ .Values.jfrog.observability.log_env | default "staging" | quote }}
         - name: FLUENTD_CONF
           value: ../../../..{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
 datadog:
@@ -57,3 +59,4 @@ jfrog:
     jpd_url: JPD_URL
     username: JPD_ADMIN_USERNAME
     common_jpd: COMMON_JPD
+    log_env: LOG_ENV

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -45,6 +45,8 @@ artifactory:
           value: {{ .Values.datadog.verify_ssl | quote}}
         - name: DATADOG_COMPRESS_DATA
           value: {{ .Values.datadog.compress_data | quote }}
+        - name: LOG_ENV
+          value: {{ .Values.jfrog.observability.log_env | default "staging" | quote }}
         - name: FLUENTD_CONF
           value: ../../../..{{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
 datadog:
@@ -57,3 +59,4 @@ jfrog:
     jpd_url: JPD_URL
     username: JPD_ADMIN_USERNAME
     common_jpd: COMMON_JPD
+    log_env: LOG_ENV

--- a/helm/jfrog_helm.env
+++ b/helm/jfrog_helm.env
@@ -5,3 +5,4 @@ export DATADOG_VERIFY_SSL=true
 export JPD_URL=http://abc.jfrog.io
 export JPD_ADMIN_USERNAME=admin
 export COMMON_JPD=false
+export LOG_ENV=staging

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -48,6 +48,8 @@ common:
           value: {{ .Values.datadog.verify_ssl | quote}}
         - name: DATADOG_COMPRESS_DATA
           value: {{ .Values.datadog.compress_data | quote }}
+        - name: LOG_ENV
+          value: {{ .Values.jfrog.observability.log_env | default "staging" | quote }}
 datadog:
   api_key: DATADOG_API_KEY
   api_host: DATADOG_API_HOST
@@ -58,3 +60,4 @@ jfrog:
     jpd_url: JPD_URL
     username: JPD_ADMIN_USERNAME
     common_jpd: COMMON_JPD
+    log_env: LOG_ENV

--- a/jfrog.env
+++ b/jfrog.env
@@ -7,4 +7,5 @@ export JPD_URL=http://abc.jfrog.io
 export JPD_ADMIN_USERNAME=admin
 export JFROG_ADMIN_TOKEN=JFROG_ADMIN_TOKEN
 export COMMON_JPD=false
+export CUSTOM_TAG=staging
 


### PR DESCRIPTION
Support for custom tag(like staging/production) in logs and metrics. 
The customer installs this log analytics solution with their production/staging artifactory/xray. 
They need a filter in datadog(or any other log vendor) to separate the staging or production logs and metrics.

After this fix, customer should now be able to see a custom tag with logs and metrics(env:staging for example here)

<img width="720" height="511" alt="image" src="https://github.com/user-attachments/assets/28d72724-4fd7-409c-b1ea-615473aaa89a" />
<img width="711" height="599" alt="image" src="https://github.com/user-attachments/assets/f47d483d-a475-4beb-b1da-3efaee8835f6" />
![Uploading image.png…]()
