### PR TITLE
JOBS-1897: Add RTFS metrics collection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.14] - April 2026
+
+* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Requires fluent-plugin-jfrog-metrics >= 0.2.16
+
 ## [1.0.13] - March 18, 2025
 
 * Update artifactory-ha helm values file

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Once this configuration is done and the application is restarted, metrics will b
 
 :bulb: Metrics are enabled by default in Xray.
 
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection.
+
 :bulb: For kubernetes based installs, openMetrics collection is enabled in the helm install commands listed in the sections below
 
 ## Fluentd Installation
@@ -390,6 +392,10 @@ This dashboard is divided into three sections Application, Audit and Requests
 #### JFrog Artifactory Metrics dashboard
 
 This dashboard tracks Artifactory System Metrics, JVM memory, Garbabe Collection, Database Connections, and HTTP Connections metrics
+
+#### JFrog RTFS Metrics
+
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to Datadog with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Datadog for monitoring RTFS-specific performance and health.
 
 #### JFrog Xray Logs dashboard
 

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -14,6 +14,23 @@
   # @log_level debug
   # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
 </source>
+# JFROG RTFS METRICS SOURCE
+# Requires fluent-plugin-jfrog-metrics >= 0.2.16 and RTFS enabled in the Artifactory deployment
+<source>
+  @type jfrog_metrics
+  @id metrics_http_rtfs
+  tag jfrog.metrics.rtfs
+  metric_prefix 'jfrog.rtfs'
+  jpd_url "#{ENV['JPD_URL']}"
+  username "#{ENV['JPD_ADMIN_USERNAME']}"
+  token "#{ENV['JFROG_ADMIN_TOKEN']}"
+  common_jpd "#{ENV['COMMON_JPD']}"
+  target_platform "DATADOG"
+  execution_interval 60s
+  request_timeout 30s
+  # @log_level debug
+  # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
+</source>
 <match jfrog.metrics.**>
   @type jfrog_send_metrics
   target_platform "DATADOG"


### PR DESCRIPTION
## Summary
- Added a new fluentd `<source>` block in `fluent.conf.rt` for collecting RTFS (Real-Time File Store) metrics from `artifactory/service/rtfs/api/v1/metrics`
- RTFS metrics are tagged with `jfrog.metrics.rtfs` and use the `jfrog.rtfs` metric prefix, flowing through the existing `<match jfrog.metrics.**>` output block (no output changes needed)
- Updated `README.md` with RTFS metrics documentation
- Updated `CHANGELOG.md` with v1.0.14 release entry

## Dependencies

- Requires `fluent-plugin-jfrog-metrics` gem >= 0.2.16 (adds `jfrog.rtfs` URL routing in `metrics_helper.rb`)

## Design Decisions

- **Separate source block** (like Xray) rather than merging into Artifactory's — each runs its own timer task independently
- **Same auth** — RTFS runs behind Artifactory's router, so `JPD_URL` + bearer token work unchanged
- **No new env vars** — reuses existing `JPD_URL`, `JPD_ADMIN_USERNAME`, `JFROG_ADMIN_TOKEN`
- **Graceful failure** — if RTFS is not deployed, the plugin logs an error and continues; Artifactory metrics are unaffected

## Test Plan

- Verify RTFS endpoint is accessible: `curl -H "Authorization: Bearer <TOKEN>" <JPD_URL>/artifactory/service/rtfs/api/v1/metrics`
- Run fluentd with updated config and confirm `jfrog.rtfs.*` metrics appear in Datadog
-Confirm `jfrog.artifactory.*` metrics still flow correctly (no regression)
- Verify graceful handling when RTFS endpoint is not available (error logged, no crash)