### PR TITLE
JOBS-2088 - Add RTFS metrics source in log-analytics-datadog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.14] - April 2026
+
+* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Requires fluent-plugin-jfrog-metrics >= 0.2.16
+
 ## [1.0.13] - March 18, 2025
 
 * Update artifactory-ha helm values file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to the log analytics integration will be documented in this file.
 
 ## [1.0.14] - April 2026
 
-* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Added RTFS (JFrog Artifactory Federation Service) metrics collection support in Artifactory fluentd config (JOBS-1897)
 * Requires fluent-plugin-jfrog-metrics >= 0.2.16
 
 ## [1.0.13] - March 18, 2025

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Once this configuration is done and the application is restarted, metrics will b
 
 :bulb: Metrics are enabled by default in Xray.
 
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection.
+
 :bulb: For kubernetes based installs, openMetrics collection is enabled in the helm install commands listed in the sections below
 
 ## Fluentd Installation
@@ -390,6 +392,10 @@ This dashboard is divided into three sections Application, Audit and Requests
 #### JFrog Artifactory Metrics dashboard
 
 This dashboard tracks Artifactory System Metrics, JVM memory, Garbabe Collection, Database Connections, and HTTP Connections metrics
+
+#### JFrog RTFS Metrics
+
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to Datadog with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Datadog for monitoring RTFS-specific performance and health.
 
 #### JFrog Xray Logs dashboard
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once this configuration is done and the application is restarted, metrics will b
 
 :bulb: Metrics are enabled by default in Xray.
 
-:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection.
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (JFrog Artifactory Federation Service), metrics are automatically collected from the `rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection.
 
 :bulb: For kubernetes based installs, openMetrics collection is enabled in the helm install commands listed in the sections below
 
@@ -395,7 +395,7 @@ This dashboard tracks Artifactory System Metrics, JVM memory, Garbabe Collection
 
 #### JFrog RTFS Metrics
 
-When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to Datadog with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Datadog for monitoring RTFS-specific performance and health.
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `rtfs/api/v1/metrics` and forwarded to Datadog with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Datadog for monitoring RTFS-specific performance and health.
 
 #### JFrog Xray Logs dashboard
 

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -14,6 +14,23 @@
   # @log_level debug
   # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
 </source>
+# JFROG RTFS METRICS SOURCE
+# Requires fluent-plugin-jfrog-metrics >= 0.2.16 and RTFS enabled in the Artifactory deployment
+<source>
+  @type jfrog_metrics
+  @id metrics_http_rtfs
+  tag jfrog.metrics.rtfs
+  metric_prefix 'jfrog.rtfs'
+  jpd_url "#{ENV['JPD_URL']}"
+  username "#{ENV['JPD_ADMIN_USERNAME']}"
+  token "#{ENV['JFROG_ADMIN_TOKEN']}"
+  common_jpd "#{ENV['COMMON_JPD']}"
+  target_platform "DATADOG"
+  execution_interval 60s
+  request_timeout 30s
+  # @log_level debug
+  # verify_ssl "#{ENV['DATADOG_VERIFY_SSL']}"
+</source>
 <match jfrog.metrics.**>
   @type jfrog_send_metrics
   target_platform "DATADOG"


### PR DESCRIPTION
Add a dedicated Fluentd source block to collect RTFS (Real-Time File Store) metrics from the /artifactory/service/rtfs/api/v1/metrics endpoint. RTFS runs as a separate service within Artifactory and its metrics are not included in the standard /artifactory/api/v1/metrics response.

Changes:
- fluent.conf.rt: New <source> block with metric_prefix 'jfrog.rtfs', tag jfrog.metrics.rtfs, target_platform DATADOG
- README.md: Document RTFS metrics collection and dashboard availability
- CHANGELOG.md: Add v1.0.14 entry

Requires: fluent-plugin-jfrog-metrics >= 0.2.16 (JOBS-2086)
Testing Done:
echo "--- 3. RTFS METRICS ENDPOINT (DIRECT) ---" echo "GET http://localhost:8082/rtfs/api/v1/metrics" curl -s -o /dev/null -w "HTTP %{http_code}, " -H "Authorization: Bearer ${TOKEN}" \ "http://localhost:8082/rtfs/api/v1/metrics" echo "Lines: $(curl -s -H "Authorization: Bearer ${TOKEN}" "http://localhost:8082/rtfs/api/v1/metrics" | wc -l | tr -d ' ')" echo "Sample metrics:" curl -s -H "Authorization: Bearer ${TOKEN}" "http://localhost:8082/rtfs/api/v1/metrics" | grep "^# TYPE" | head -5 | sed 's/^/  /' echo ""

Fluentd Logs: RTFS Metrics Successfully Collected
```
[info]: Executing jfrog.rtfs metrics collection from: http://host.docker.internal:8082/rtfs/api/v1/metrics
[info]: jfrog.rtfs metrics were successfully collected from url: http://host.docker.internal:8082/rtfs/api/v1/metrics
[info]: Metrics collection finished
[info]: Sending metrics to target platform: DATADOG started
[debug]: Compressed metrics payload size: 4974 bytes
[info]: Metrics were successfully sent to DataDog
[info]: Sending metrics to target platform: DATADOG finished
```

Fluentd Logs: Artifactory Metrics (running in parallel)
```
[info]: Executing jfrog.artifactory metrics collection from: http://host.docker.internal:8082/artifactory/api/v1/metrics
[info]: jfrog.artifactory metrics were successfully collected from url: http://host.docker.internal:8082/artifactory/api/v1/metrics
[info]: Metrics collection finished
[info]: Sending metrics to target platform: DATADOG started
[debug]: Compressed metrics payload size: 12147 bytes
[info]: Metrics were successfully sent to DataDog
Datadog Verification
```

140 distinct jfrog.rtfs.* metrics confirmed in Datadog Metrics Summary, including:
```
- `jfrog.rtfs.disk_free_bytes`
- `jfrog.rtfs.disk_total_bytes`
- `jfrog.rtfs.hikaricp_connections_active`
- `jfrog.rtfs.hikaricp_connections_idle`
- `jfrog.rtfs.http_server_requests_seconds`
- `jfrog.rtfs.executor_active_threads`
- `jfrog.rtfs.application_ready_time_seconds`
- ... and 133 more
```

<img width="1645" height="1002" alt="Screenshot 2026-04-21 at 4 02 33 PM" src="https://github.com/user-attachments/assets/d4263967-c208-444d-8067-ed9b07e0782a" />
