### PR TITLE
JOBS-2479: Bump fluentd sidecar image to 4.20 (Helm values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.16] - June 2026
+
+* Fluentd sidecar image bumped to 4.20: migrated to Echo secure base (fluentd 1.19.2, Debian 13), remediating Critical/High CVEs in 4.19 (JOBS-2475)
+* Pinned fluent-plugin-jfrog-metrics ~> 0.2.17
+
 ## [1.0.15] - April 2026
 
 * Fix incorrect field name in access-security-audit log parsing: renamed `token_id` capture group to `trace_id` to match the actual log format documented at https://docs.jfrog.com/administration/docs/audit-trail-log (JOBS-2031)

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts: 
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
## Summary
Bumps the fluentd sidecar image from `4.19` to `4.20` across all Helm value files (artifactory, artifactory-ha, xray) + CHANGELOG. `4.20` is the Echo secure base image (CVE remediation, JOBS-2475). The Dockerfile change is in #73.

## Merge order (do not merge early)
Merge this **only after** `releases-docker.jfrog.io/fluentd:4.20` is built and promoted (JOBS-2478). These are public repos — merging before `4.20` is pullable causes ImagePullBackOff for customers deploying from master. See JOBS-2487.

## Changes
- `helm/artifactory-values.yaml`, `helm/artifactory-ha-values.yaml`, `helm/xray-values.yaml`: `fluentd:4.19` -> `fluentd:4.20`
- `CHANGELOG.md`: 4.20 release note